### PR TITLE
Fix rspec gem version, fails on rspec >= 3.0 due to changes in mock method

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gemspec
 gem "rake"
 
 group :test do
-  gem 'rspec'
+  gem 'rspec', '~> 2.0'
   gem "vcr"
   gem 'faraday'
 end


### PR DESCRIPTION
Should look into upgrading to rspec-core >= 3.0 and write a new PR to fix mock errors for specs.